### PR TITLE
fix invalid underscore in ros2_control node name

### DIFF
--- a/so_arm100_description/control/so_arm100.ros2_control.xacro
+++ b/so_arm100_description/control/so_arm100.ros2_control.xacro
@@ -4,7 +4,7 @@
     name="ros2_control"
     params="prefix ros2_control_hardware_type usb_port"
   >
-    <ros2_control name="SO-ARM100" type="system">
+    <ros2_control name="SO_ARM100" type="system">
       <hardware>
         <xacro:if value="${ros2_control_hardware_type == 'mock_components'}">
           <plugin>mock_components/GenericSystem</plugin>


### PR DESCRIPTION
In Jazzy I ran into the following error which this PR fixes:

```
[ros2_control_node-1] [controller_manager] [1760378906.949394178] [INFO] [load_hardware():168]: Loaded hardware 'SO-ARM100' from plugin 'mock_components/GenericSystem'
[ros2_control_node-1] [controller_manager] [1760378906.949423445] [INFO] [initialize_hardware():232]: Initialize hardware 'SO-ARM100' 
[ros2_control_node-1] [controller_manager] [1760378906.949505042] [ERROR] [initialize_hardware():256]: Exception of type : N6rclcpp10exceptions20InvalidNodeNameErrorE occurred while initializing hardware 'SO-ARM100': Invalid node name: node name must not contain characters other than alphanumerics or '_':
[ros2_control_node-1]   'so-arm100'
[ros2_control_node-1]      ^
[ros2_control_node-1] 
[ros2_control_node-1] [controller_manager] [1760378906.949533483] [WARN] [operator()():1163]: System hardware component 'SO-ARM100' from plugin 'mock_components/GenericSystem' failed to initialize.
[ros2_control_node-1] [controller_manager] [1760378906.949549071] [WARN] [init_resource_manager():652]: Could not load and initialize hardware. Please check previous output for more details. After you have corrected your URDF, try to publish robot description again
```