### PR TITLE
Removes mujoco_vendor clone instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ git clone https://github.com/JafarAbdi/feetech_ros2_driver.git
 
 # 3. (Optional) MuJoCo packages
 git clone https://github.com/ros-controls/mujoco_ros2_control.git
-git clone https://github.com/pal-robotics/mujoco_vendor.git
 
 # 4. Pull the CAD submodule
 git -C ros2_so_arm100 submodule update --init --recursive


### PR DESCRIPTION
No longer needed since mujoco_vendor is now available in ros2-gbp: https://github.com/ros2-gbp/mujoco_vendor-release