### PR TITLE
Fix default joint positions for SO-101

### DIFF
--- a/so_arm101_description/launch/view_description.launch.py
+++ b/so_arm101_description/launch/view_description.launch.py
@@ -1,0 +1,100 @@
+"""Launch file to visualize the SO-ARM101 robot model.
+
+Launches the robot_state_publisher with the SO-ARM101 URDF (processed via xacro),
+a joint_state_publisher_gui for interactive joint control, and optionally RViz
+for 3D visualization.
+
+Usage:
+    ros2 launch so_arm101_description view_description.launch.py
+    ros2 launch so_arm101_description view_description.launch.py rviz:=true
+    ros2 launch so_arm101_description view_description.launch.py joint_state_publisher:=false
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+from launch_ros.actions import Node
+from launch_ros.descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    # Arguments
+    rviz_arg = DeclareLaunchArgument(
+        "rviz", default_value="false", description="Open RViz."
+    )
+    jsp_arg = DeclareLaunchArgument(
+        "joint_state_publisher",
+        default_value="true",
+        description="Run joint state publisher gui node.",
+    )
+
+    pkg_so_arm101_description = get_package_share_directory("so_arm101_description")
+
+    # Robot description via xacro
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("so_arm101_description"),
+                    "urdf",
+                    "so_arm101.urdf.xacro",
+                ]
+            ),
+        ]
+    )
+
+    # Robot State Publisher
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="both",
+        parameters=[
+            {
+                "robot_description": ParameterValue(
+                    robot_description_content, value_type=str
+                )
+            }
+        ],
+    )
+
+    # Joint State Publisher GUI
+    joint_state_publisher_gui = Node(
+        package="joint_state_publisher_gui",
+        executable="joint_state_publisher_gui",
+        name="joint_state_publisher_gui",
+        condition=IfCondition(LaunchConfiguration("joint_state_publisher")),
+    )
+
+    # RViz
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        arguments=[
+            "-d",
+            os.path.join(pkg_so_arm101_description, "rviz", "config.rviz"),
+        ],
+        condition=IfCondition(LaunchConfiguration("rviz")),
+    )
+
+    return LaunchDescription(
+        [
+            rviz_arg,
+            jsp_arg,
+            robot_state_publisher,
+            joint_state_publisher_gui,
+            rviz,
+        ]
+    )

--- a/so_arm101_description/mjcf/so_arm101.xml
+++ b/so_arm101_description/mjcf/so_arm101.xml
@@ -271,13 +271,13 @@
             <body
               name="wrist_link"
               pos="-0.1349 0.0052 3.62355e-17"
-              quat="0.707107 9.58722e-16 -7.51313e-16 -0.707107"
+              quat="1 -3.94784e-16 1.66357e-15 3.78078e-09"
             >
               <joint
                 axis="0 0 1"
                 name="wrist_flex_joint"
                 type="hinge"
-                range="-1.6580628494556928 1.6580627293335335"
+                range="-3.5 0.2"
                 class="sts3215"
               />
               <inertial
@@ -317,13 +317,13 @@
               <body
                 name="gripper_link"
                 pos="5.55112e-17 -0.0611 0.0181"
-                quat="0.0172091 -0.0172091 0.706897 0.706897"
+                quat="0.5 -0.5 0.5 0.5"
               >
                 <joint
                   axis="0 0 1"
                   name="wrist_roll_joint"
                   type="hinge"
-                  range="-2.7438472969992493 2.841206309382605"
+                  range="-1.0 4.0"
                   class="sts3215"
                 />
                 <inertial

--- a/so_arm101_description/mjcf/so_arm101.xml
+++ b/so_arm101_description/mjcf/so_arm101.xml
@@ -217,7 +217,7 @@
               axis="0 0 1"
               name="elbow_flex_joint"
               type="hinge"
-              range="-1.69 1.69"
+              range="-1.69 1.54"
               class="sts3215"
             />
             <inertial
@@ -271,13 +271,13 @@
             <body
               name="wrist_link"
               pos="-0.1349 0.0052 3.62355e-17"
-              quat="1 -3.94784e-16 1.66357e-15 3.78078e-09"
+              quat="0.707388 0.0 0.0 -0.706825"
             >
               <joint
                 axis="0 0 1"
                 name="wrist_flex_joint"
                 type="hinge"
-                range="-3.5 0.2"
+                range="-1.6 1.6"
                 class="sts3215"
               />
               <inertial
@@ -316,14 +316,14 @@
               <!-- Link gripper -->
               <body
                 name="gripper_link"
-                pos="5.55112e-17 -0.0611 0.0181"
-                quat="0.5 -0.5 0.5 0.5"
+                pos="0.0 -0.0611 0.0181"
+                quat="0.000563 -0.000563 0.707388 0.706825"
               >
                 <joint
                   axis="0 0 1"
                   name="wrist_roll_joint"
                   type="hinge"
-                  range="-1.0 4.0"
+                  range="-2.3 2.3"
                   class="sts3215"
                 />
                 <inertial
@@ -369,13 +369,13 @@
                 <body
                   name="jaw_link"
                   pos="0.0202 0.0188 -0.0234"
-                  quat="0.707107 0.707107 -1.85362e-08 1.85362e-08"
+                  quat="0.704244 0.704246 0.063554 -0.063554"
                 >
                   <joint
                     axis="0 0 1"
                     name="gripper_joint"
                     type="hinge"
-                    range="-0.17453297762778586 1.7453291995659765"
+                    range="0.0 1.0"
                     class="sts3215"
                   />
                   <inertial
@@ -426,28 +426,28 @@
       name="elbow_flex_joint"
       joint="elbow_flex_joint"
       forcerange="-3.35 3.35"
-      ctrlrange="-1.69 1.69"
+      ctrlrange="-1.69 1.54"
     />
     <position
       class="sts3215"
       name="wrist_flex_joint"
       joint="wrist_flex_joint"
       forcerange="-3.35 3.35"
-      ctrlrange="-1.65806 1.65806"
+      ctrlrange="-1.6 1.6"
     />
     <position
       class="sts3215"
       name="wrist_roll_joint"
       joint="wrist_roll_joint"
       forcerange="-3.35 3.35"
-      ctrlrange="-2.74385 2.84121"
+      ctrlrange="-2.3 2.3"
     />
     <position
       class="sts3215"
       name="gripper_joint"
       joint="gripper_joint"
       forcerange="-3.35 3.35"
-      ctrlrange="-0.17453 1.74533"
+      ctrlrange="0.0 1.0"
     />
   </actuator>
 

--- a/so_arm101_description/urdf/so_arm101_macro.xacro
+++ b/so_arm101_description/urdf/so_arm101_macro.xacro
@@ -611,12 +611,12 @@
     <joint name="${prefix}wrist_flex_joint" type="revolute">
       <origin
         xyz="-0.1349 0.0052 3.62355e-17"
-        rpy="4.02456e-15 8.67362e-16 -1.5708"
+        rpy="-1.41553e-15 4.91611e-15 7.56157e-09"
       />
       <parent link="${prefix}lower_arm_link" />
       <child link="${prefix}wrist_link" />
       <axis xyz="0 0 1" />
-      <limit effort="10" velocity="10" lower="-1.65806" upper="1.65806" />
+      <limit effort="10" velocity="10" lower="-3.5" upper="0.2" />
     </joint>
 
     <transmission name="${prefix}wrist_flex_trans">
@@ -636,11 +636,11 @@
 
     <!-- Joint from wrist to gripper -->
     <joint name="${prefix}wrist_roll_joint" type="revolute">
-      <origin xyz="5.55112e-17 -0.0611 0.0181" rpy="1.5708 0.0486795 3.14159" />
+      <origin xyz="2.77556e-17 -0.0611 0.0181" rpy="1.5708 1.5708 3.14159" />
       <parent link="${prefix}wrist_link" />
       <child link="${prefix}gripper_link" />
       <axis xyz="0 0 1" />
-      <limit effort="10" velocity="10" lower="-2.74385" upper="2.84121" />
+      <limit effort="10" velocity="10" lower="-1.0" upper="4.0" />
     </joint>
 
     <transmission name="${prefix}wrist_roll_trans">

--- a/so_arm101_description/urdf/so_arm101_macro.xacro
+++ b/so_arm101_description/urdf/so_arm101_macro.xacro
@@ -589,7 +589,7 @@
       <parent link="${prefix}upper_arm_link" />
       <child link="${prefix}lower_arm_link" />
       <axis xyz="0 0 1" />
-      <limit effort="10" velocity="10" lower="-1.69" upper="1.69" />
+      <limit effort="10" velocity="10" lower="-1.69" upper="1.54" />
     </joint>
 
     <transmission name="${prefix}elbow_flex_trans">
@@ -611,12 +611,12 @@
     <joint name="${prefix}wrist_flex_joint" type="revolute">
       <origin
         xyz="-0.1349 0.0052 3.62355e-17"
-        rpy="-1.41553e-15 4.91611e-15 7.56157e-09"
+        rpy="-1.41553e-15 4.91611e-15 -1.57"
       />
       <parent link="${prefix}lower_arm_link" />
       <child link="${prefix}wrist_link" />
       <axis xyz="0 0 1" />
-      <limit effort="10" velocity="10" lower="-3.5" upper="0.2" />
+      <limit effort="10" velocity="10" lower="-1.6" upper="1.6" />
     </joint>
 
     <transmission name="${prefix}wrist_flex_trans">
@@ -636,11 +636,11 @@
 
     <!-- Joint from wrist to gripper -->
     <joint name="${prefix}wrist_roll_joint" type="revolute">
-      <origin xyz="2.77556e-17 -0.0611 0.0181" rpy="1.5708 1.5708 3.14159" />
+      <origin xyz="0.0 -0.0611  0.0181" rpy="-1.57 3.14 0" />
       <parent link="${prefix}wrist_link" />
       <child link="${prefix}gripper_link" />
       <axis xyz="0 0 1" />
-      <limit effort="10" velocity="10" lower="-1.0" upper="4.0" />
+      <limit effort="10" velocity="10" lower="-2.3" upper="2.3" />
     </joint>
 
     <transmission name="${prefix}wrist_roll_trans">
@@ -668,14 +668,11 @@
 
     <!-- Joint from gripper to jaw -->
     <joint name="${prefix}gripper_joint" type="revolute">
-      <origin
-        xyz="0.0202 0.0188 -0.0234"
-        rpy="1.5708 -5.24284e-08 -1.41553e-15"
-      />
+      <origin xyz="0.0202 0.0188 -0.0234" rpy="1.5708 0.18 -1.41553e-15" />
       <parent link="${prefix}gripper_link" />
       <child link="${prefix}jaw_link" />
       <axis xyz="0 0 1" />
-      <limit effort="10" velocity="10" lower="-0.174533" upper="1.74533" />
+      <limit effort="10" velocity="10" lower="0.0" upper="1." />
     </joint>
 
     <transmission name="${prefix}gripper_trans">


### PR DESCRIPTION
This is done to match the SO-100 loading, and also the home position of the robot being zeros.

Before:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d67caf1a-1b14-4b78-8182-0c06df7e77f8" />

After:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cf930782-a6a6-4802-8818-a5fb3420a9c5" />


Addresses https://github.com/ros-physical-ai/demos/issues/24